### PR TITLE
Local storage of game state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "fuse.js": "^7.0.0",
         "lucide-react": "^0.436.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -1047,6 +1048,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3635,6 +3645,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "fuse.js": "^7.0.0",
     "lucide-react": "^0.436.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,23 @@ import "./App.css";
 import { Game } from "./page/Game";
 import { PageLayout } from "./page/PageLayout";
 import { ThemeProvider } from "./theme-provider";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 function App() {
   return (
     <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
-      <PageLayout header={"The Wiki Game"} content={<Game />} />
+      <Router>
+        <Routes>
+          <Route
+            path="/"
+            element={<PageLayout header={"The Wiki Game"} content={<Game />} />}
+          />
+          <Route
+            path="/:game_id"
+            element={<PageLayout header={"The Wiki Game"} content={<Game />} />}
+          />
+        </Routes>
+      </Router>
     </ThemeProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
             element={<PageLayout header={"The Wiki Game"} content={<Game />} />}
           />
           <Route
-            path="/:game_id"
+            path="/:gameId"
             element={<PageLayout header={"The Wiki Game"} content={<Game />} />}
           />
         </Routes>

--- a/src/feature/local-storage/LocalStorageHook.ts
+++ b/src/feature/local-storage/LocalStorageHook.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+const useLocalStorage = <T>(key: string, defaultValue: T) => {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") return defaultValue;
+
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : defaultValue;
+    } catch (error) {
+      console.log(error);
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(key, JSON.stringify(storedValue));
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }, [key, storedValue]);
+
+  return [storedValue, setStoredValue] as const;
+};
+
+export default useLocalStorage;

--- a/src/feature/local-storage/LocalStorageHook.ts
+++ b/src/feature/local-storage/LocalStorageHook.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 const useLocalStorage = <T>(key: string, defaultValue: T) => {
   const [storedValue, setStoredValue] = useState<T>(() => {
+    if (!key) return defaultValue;
     if (typeof window === "undefined") return defaultValue;
 
     try {

--- a/src/feature/local-storage/LocalStorageHook.ts
+++ b/src/feature/local-storage/LocalStorageHook.ts
@@ -27,4 +27,27 @@ const useLocalStorage = <T>(key: string, defaultValue: T) => {
   return [storedValue, setStoredValue] as const;
 };
 
-export default useLocalStorage;
+const useSyncedLocalStorage = <T>(key: string, initialValue: T) => {
+  const [storedValue, setStoredValue] = useLocalStorage<T>(key, initialValue);
+
+  useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === key) {
+        const newValue = event.newValue
+          ? JSON.parse(event.newValue)
+          : initialValue;
+        setStoredValue(newValue);
+      }
+    };
+
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, [key, initialValue, setStoredValue]);
+
+  return [storedValue, setStoredValue] as const;
+};
+
+export { useSyncedLocalStorage, useLocalStorage };

--- a/src/page/Game.tsx
+++ b/src/page/Game.tsx
@@ -9,15 +9,18 @@ import { GameState } from "../model/GameState";
 import { Page } from "../model/Page";
 import { logger } from "../util/Logger";
 import { useNavigate, useParams } from "react-router-dom";
-import useLocalStorage from "../feature/local-storage/LocalStorageHook";
+import { useSyncedLocalStorage } from "../feature/local-storage/LocalStorageHook";
 
 type GameProps = {} & React.ComponentProps<"div">;
 
 export const Game = ({ className, ...props }: GameProps) => {
   const { gameId } = useParams<{ gameId: string }>();
-  const [gameState, setGameState] = useLocalStorage<GameState>(gameId || "", {
-    history: [],
-  });
+  const [gameState, setGameState] = useSyncedLocalStorage<GameState>(
+    gameId || "",
+    {
+      history: [],
+    }
+  );
   const navigate = useNavigate();
 
   const [options, setOptions] = useState<Page[]>([]);

--- a/src/page/Game.tsx
+++ b/src/page/Game.tsx
@@ -8,17 +8,17 @@ import { dataSourceController } from "../data/DataSourceController";
 import { GameState } from "../model/GameState";
 import { Page } from "../model/Page";
 import { logger } from "../util/Logger";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import useLocalStorage from "../feature/local-storage/LocalStorageHook";
 
 type GameProps = {} & React.ComponentProps<"div">;
 
 export const Game = ({ className, ...props }: GameProps) => {
   const { gameId } = useParams<{ gameId: string }>();
-  const validGameId = gameId || crypto.randomUUID();
-  const [gameState, setGameState] = useLocalStorage<GameState>(validGameId, {
+  const [gameState, setGameState] = useLocalStorage<GameState>(gameId || "", {
     history: [],
   });
+  const navigate = useNavigate();
 
   const [options, setOptions] = useState<Page[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -30,6 +30,13 @@ export const Game = ({ className, ...props }: GameProps) => {
     () => gameState,
     [gameState]
   );
+
+  useEffect(() => {
+    if (gameId) {
+      return;
+    }
+    navigate(`/${crypto.randomUUID()}`, { replace: true });
+  }, [gameId, navigate]);
 
   useEffect(() => {
     logger.debug("Initializing game state");
@@ -56,7 +63,7 @@ export const Game = ({ className, ...props }: GameProps) => {
     };
 
     initializeGame();
-  }, [start, end, gameState]);
+  }, [start, end, gameState, gameId, setGameState]);
 
   useEffect(() => {
     logger.debug("Retrieving internal links on current page");


### PR DESCRIPTION
- Created `useLocalStorage` and `useSyncedLocalStorage` hooks to track game state
- Added `react-router-dom` dependency for routes and parameters to input game ids

---

Currently if a user wants to they can create a custom game url like `https://<tbd-domain>.com/literally-anything` and it will be a valid game ID. Its not a bug per se, but it is something we should be aware of.

One thing we could do to fix this is to generate the game id based off of a hash of the start vs end article. This way we could detect if it is a valid game by comparing the articles to the id.

This could lead to an issue with overlap of custom to daily games, but could be resolved with prefixing the game ids like `custom/<game-id>` vs `daily/<game-id>`.